### PR TITLE
nationex: normalize additional tracking statuses

### DIFF
--- a/plugins/nationex/karrio/providers/nationex/tracking.py
+++ b/plugins/nationex/karrio/providers/nationex/tracking.py
@@ -40,7 +40,7 @@ def _extract_details(
             for status in list(provider_units.TrackingStatus)
             if shipment.ShipmentStatus in status.value
         ),
-        provider_units.TrackingStatus.in_transit.name,
+        provider_units.TrackingStatus.unknown.name,
     )
 
     return models.TrackingDetails(

--- a/plugins/nationex/karrio/providers/nationex/units.py
+++ b/plugins/nationex/karrio/providers/nationex/units.py
@@ -89,11 +89,17 @@ def shipping_options_initializer(
 
 
 class TrackingStatus(lib.Enum):
-    on_hold = ["OnHold", "Attention"]
-    delivered = ["Delivered"]
-    in_transit = ["Pickup", "Transit"]
-    delivery_failed = ["ReturnToSender", "RefusedDelivery"]
+    # Nationex shipment states normalized to Karrio tracker status values.
+    pending = ["Creation", "DataReceived"]
+    picked_up = ["Pickup", "PartiallyPickedUp"]
+    in_transit = ["Transit", "PartiallyInTransit"]
     out_for_delivery = ["OutForDelivery", "PartiallyOutForDelivery"]
+    delivered = ["Delivered", "PartiallyDelivered"]
+    on_hold = ["OnHold", "Attention", "PickupAttemptFailed", "RefusedDelivery"]
+    cancelled = ["Cancelled"]
+    return_to_sender = ["ReturnCompleted", "ReturnToSender"]
+    ready_for_pickup = ["OutForPickup"]
+    unknown = ["Unknown"]
 
 
 class TrackingIncidentReason(lib.Enum):

--- a/plugins/nationex/tests/nationex/test_tracking.py
+++ b/plugins/nationex/tests/nationex/test_tracking.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 from unittest.mock import patch, ANY
 from .fixture import gateway
 
@@ -36,6 +37,44 @@ class TestNationexTracking(unittest.TestCase):
 
             self.assertListEqual(lib.to_dict(parsed_response), ParsedTrackingResponse)
 
+    def test_status_mapping(self):
+        status_expectations = {
+            "Creation": "pending",
+            "DataReceived": "pending",
+            "Pickup": "picked_up",
+            "PartiallyPickedUp": "picked_up",
+            "Transit": "in_transit",
+            "PartiallyInTransit": "in_transit",
+            "OutForDelivery": "out_for_delivery",
+            "PartiallyOutForDelivery": "out_for_delivery",
+            "Delivered": "delivered",
+            "PartiallyDelivered": "delivered",
+            "OnHold": "on_hold",
+            "Attention": "on_hold",
+            "PickupAttemptFailed": "on_hold",
+            "RefusedDelivery": "on_hold",
+            "Cancelled": "cancelled",
+            "ReturnCompleted": "return_to_sender",
+            "ReturnToSender": "return_to_sender",
+            "OutForPickup": "ready_for_pickup",
+            "SomethingUnexpected": "unknown",
+        }
+
+        for nationex_status, expected_karrio_status in status_expectations.items():
+            with self.subTest(nationex_status=nationex_status):
+                tracking_response = json.loads(TrackingResponse)
+                tracking_response["ShipmentStatus"] = nationex_status
+                tracking_response["StatusHistories"][0]["ShipmentStatus"] = nationex_status
+
+                with patch("karrio.mappers.nationex.proxy.lib.request") as mock:
+                    mock.return_value = json.dumps(tracking_response)
+                    parsed_response = (
+                        karrio.Tracking.fetch(self.TrackingRequest).from_(gateway).parse()
+                    )
+
+                tracking = lib.to_dict(parsed_response)[0][0]
+                self.assertEqual(tracking["status"], expected_karrio_status)
+
     def test_parse_error_response(self):
         with patch("karrio.mappers.nationex.proxy.lib.request") as mock:
             mock.return_value = ErrorResponse
@@ -66,6 +105,7 @@ ParsedTrackingResponse = [
                     "date": "2019-08-24",
                     "description": "Data received",
                     "location": "St-Hubert",
+                    "status": "pending",
                     "time": "14:15 PM",
                     "timestamp": "2019-08-24T14:15:22.000Z",
                 }
@@ -83,7 +123,7 @@ ParsedTrackingResponse = [
                 "shipping_date": "2021-03-30",
             },
             "meta": {"accounty_number": "165556", "reference": "CX4335"},
-            "status": "in_transit",
+            "status": "pending",
             "tracking_number": "103882774",
         }
     ],


### PR DESCRIPTION
## Summary
- expand Nationex tracking status normalization for additional carrier states
- map `Creation` and `DataReceived` to `pending`
- map partial delivery, pickup, cancellation, return, and pickup-ready statuses explicitly
- fallback unknown carrier states to `unknown`
- keep POD/base64 image handling out of scope for this PR

## Review updates
- Rebuilt on current `karrioapi/community:main` as a single focused commit.
- Confirmed current community `main` already has the Nationex rate `Content-Type: application/json` fix, so this PR now carries only tracking status normalization.

## Validation
```bash
.venv/bin/python -m pytest plugins/nationex/tests/nationex -q
```
Result: `14 passed, 1 warning, 19 subtests passed`.
